### PR TITLE
♻️ Add a delegate function when the deserialization fails

### DIFF
--- a/Sources/Internal/BridgeTransport.swift
+++ b/Sources/Internal/BridgeTransport.swift
@@ -11,7 +11,7 @@ protocol Transport {
         onConnect: @escaping ((WCURL) -> Void),
         onDisconnect: @escaping ((WCURL, Error?) -> Void),
         onTextReceive: @escaping (String, WCURL) -> Void,
-        onDeserializationError: @escaping ((WCURL) -> Void)
+        onError: @escaping ((WCURL, Error?) -> Void)
     )
     func isConnected(by url: WCURL) -> Bool
     func disconnect(from url: WCURL)
@@ -40,7 +40,7 @@ class Bridge: Transport {
         onConnect: @escaping ((WCURL) -> Void),
         onDisconnect: @escaping ((WCURL, Error?) -> Void),
         onTextReceive: @escaping (String, WCURL) -> Void,
-        onDeserializationError: @escaping ((WCURL) -> Void)
+        onError: @escaping ((WCURL, Error?) -> Void)
     ) {
         dispatchPrecondition(condition: .notOnQueue(syncQueue))
         syncQueue.sync { [weak self] in
@@ -58,7 +58,9 @@ class Bridge: Transport {
                         onDisconnect(url, error)
                     },
                     onTextReceive: { text in onTextReceive(text, url) },
-                    onDeserializationError: { onDeserializationError(url) }
+                    onError: { error in
+                        onError(url, error)
+                    }
                 )
                 self.connections.append(connection)
             }

--- a/Sources/Internal/Communicator.swift
+++ b/Sources/Internal/Communicator.swift
@@ -68,14 +68,14 @@ class Communicator {
         onConnect: @escaping ((WCURL) -> Void),
         onDisconnect: @escaping ((WCURL, Error?) -> Void),
         onTextReceive: @escaping (String, WCURL) -> Void,
-        onDeserializationError: @escaping ((WCURL) -> Void)
+        onError: @escaping ((WCURL, Error?) -> Void)
     ) {
         transport.listen(
             on: url,
             onConnect: onConnect,
             onDisconnect: onDisconnect,
             onTextReceive: onTextReceive,
-            onDeserializationError: onDeserializationError
+            onError: onError
         )
     }
 

--- a/Sources/Internal/Communicator.swift
+++ b/Sources/Internal/Communicator.swift
@@ -63,14 +63,20 @@ class Communicator {
 
     // MARK: - Transport
 
-    func listen(on url: WCURL,
-                onConnect: @escaping ((WCURL) -> Void),
-                onDisconnect: @escaping ((WCURL, Error?) -> Void),
-                onTextReceive: @escaping (String, WCURL) -> Void) {
-        transport.listen(on: url,
-                         onConnect: onConnect,
-                         onDisconnect: onDisconnect,
-                         onTextReceive: onTextReceive)
+    func listen(
+        on url: WCURL,
+        onConnect: @escaping ((WCURL) -> Void),
+        onDisconnect: @escaping ((WCURL, Error?) -> Void),
+        onTextReceive: @escaping (String, WCURL) -> Void,
+        onDeserializationError: @escaping ((WCURL) -> Void)
+    ) {
+        transport.listen(
+            on: url,
+            onConnect: onConnect,
+            onDisconnect: onDisconnect,
+            onTextReceive: onTextReceive,
+            onDeserializationError: onDeserializationError
+        )
     }
 
     func subscribe(on topic: String, url: WCURL) {

--- a/Sources/Internal/WebSocketConnection.swift
+++ b/Sources/Internal/WebSocketConnection.swift
@@ -39,7 +39,7 @@ class WebSocketConnection {
     private let onConnect: (() -> Void)?
     private let onDisconnect: ((Error?) -> Void)?
     private let onTextReceive: ((String) -> Void)?
-    private let onDeserializationError: (() -> Void)?
+    private let onError: ((Error?) -> Void)?
 
     // needed to keep connection alive
     private var pingTimer: Timer?
@@ -59,13 +59,13 @@ class WebSocketConnection {
          onConnect: (() -> Void)?,
          onDisconnect: ((Error?) -> Void)?,
          onTextReceive: ((String) -> Void)?,
-         onDeserializationError: (() -> Void)?
+         onError: ((Error?) -> Void)?
     ) {
         self.url = url
         self.onConnect = onConnect
         self.onDisconnect = onDisconnect
         self.onTextReceive = onTextReceive
-        self.onDeserializationError = onDeserializationError
+        self.onError = onError
 
     #if os(iOS)
         // On actual iOS devices, request some additional background execution time to the OS
@@ -245,7 +245,7 @@ private extension WebSocketConnection {
                     LogService.shared.detailed("WC: ==> \(text)")
                 }
                 
-                onDeserializationError?()
+                onError?(error)
             }
         case .pingSent:
             LogService.shared.verbose("WC: ==> ping")

--- a/Sources/PublicInterface/Server.swift
+++ b/Sources/PublicInterface/Server.swift
@@ -28,7 +28,7 @@ public protocol ServerDelegate: AnyObject {
     func server(_ server: Server, didUpdate session: Session)
     
     /// Called only when there is an error about the deserialization.
-    func server(_ server: Server, didFailDeserializationFor url: WCURL)
+    func server(_ server: Server, didFailWithError: Error?, for url: WCURL)
 }
 
 public protocol ServerDelegateV2: ServerDelegate {
@@ -155,10 +155,11 @@ open class Server: WalletConnect {
         }
     }
     
-    override func onDeserializationError(for url: WCURL) {
+    override func onError(for url: WCURL, error: Error?) {
         delegate?.server(
             self,
-            didFailDeserializationFor: url
+            didFailWithError: error,
+            for: url
         )
     }
 

--- a/Sources/PublicInterface/Server.swift
+++ b/Sources/PublicInterface/Server.swift
@@ -28,7 +28,7 @@ public protocol ServerDelegate: AnyObject {
     func server(_ server: Server, didUpdate session: Session)
     
     /// Called only when there is an error about the deserialization.
-    func server(_ server: Server, didFailWithError: Error?, for url: WCURL)
+    func server(_ server: Server, didFailWith error: Error?, for url: WCURL)
 }
 
 public protocol ServerDelegateV2: ServerDelegate {
@@ -158,7 +158,7 @@ open class Server: WalletConnect {
     override func onError(for url: WCURL, error: Error?) {
         delegate?.server(
             self,
-            didFailWithError: error,
+            didFailWith: error,
             for: url
         )
     }

--- a/Sources/PublicInterface/Server.swift
+++ b/Sources/PublicInterface/Server.swift
@@ -26,6 +26,9 @@ public protocol ServerDelegate: AnyObject {
 
     /// Called only when the session is updated with intention of the dAppt.
     func server(_ server: Server, didUpdate session: Session)
+    
+    /// Called only when there is an error about the deserialization.
+    func server(_ server: Server, didFailDeserializationFor url: WCURL)
 }
 
 public protocol ServerDelegateV2: ServerDelegate {
@@ -150,6 +153,13 @@ open class Server: WalletConnect {
         if let delegate = delegate as? ServerDelegateV2 {
             delegate.server(self, willReconnect: session)
         }
+    }
+    
+    override func onDeserializationError(for url: WCURL) {
+        delegate?.server(
+            self,
+            didFailDeserializationFor: url
+        )
     }
 
     /// Sends response for the create session request.

--- a/Sources/PublicInterface/WalletConnect.swift
+++ b/Sources/PublicInterface/WalletConnect.swift
@@ -67,15 +67,15 @@ open class WalletConnect {
         let onTextReceive: ((String, WCURL) -> Void) = { [weak self] (text, url) in
             self?.onTextReceive(text, from: url)
         }
-        let onDeserializationError: ((WCURL) -> Void) = { [weak self] (url) in
-            self?.onDeserializationError(for: url)
+        let onError: ((WCURL, Error?) -> Void) = { [weak self] (url, error) in
+            self?.onError(for: url, error: error)
         }
         communicator.listen(
             on: url,
             onConnect: onConnect,
             onDisconnect: onDisconnect,
             onTextReceive: onTextReceive,
-            onDeserializationError: onDeserializationError
+            onError: onError
         )
     }
 
@@ -135,7 +135,7 @@ open class WalletConnect {
         preconditionFailure("Should be implemented in subclasses")
     }
     
-    func onDeserializationError(for url: WCURL) {
+    func onError(for url: WCURL, error: Error?) {
         preconditionFailure("Should be implemented in subclasses")
     }
 

--- a/Sources/PublicInterface/WalletConnect.swift
+++ b/Sources/PublicInterface/WalletConnect.swift
@@ -67,10 +67,16 @@ open class WalletConnect {
         let onTextReceive: ((String, WCURL) -> Void) = { [weak self] (text, url) in
             self?.onTextReceive(text, from: url)
         }
-        communicator.listen(on: url,
-                            onConnect: onConnect,
-                            onDisconnect: onDisconnect,
-                            onTextReceive: onTextReceive)
+        let onDeserializationError: ((WCURL) -> Void) = { [weak self] (url) in
+            self?.onDeserializationError(for: url)
+        }
+        communicator.listen(
+            on: url,
+            onConnect: onConnect,
+            onDisconnect: onDisconnect,
+            onTextReceive: onTextReceive,
+            onDeserializationError: onDeserializationError
+        )
     }
 
     /// Confirmation from Transport layer that connection was successfully established.
@@ -126,6 +132,10 @@ open class WalletConnect {
     }
 
     func willReconnect(_ session: Session) {
+        preconditionFailure("Should be implemented in subclasses")
+    }
+    
+    func onDeserializationError(for url: WCURL) {
         preconditionFailure("Should be implemented in subclasses")
     }
 


### PR DESCRIPTION
Sometimes the wallet connect messages are failing to be deserialized. We decided to add a new delegate function to be able to track the count of the deserialization errors so that we can see the real time usage effects of this issue.